### PR TITLE
Update `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 # separate concurrency for branches/PRs so previews don't block each other
 concurrency:
-  group: pages-${{ github.ref }}
+  group: hugo-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Rename the workflow concurrency group so it doesn’t start with `pages-`

GitHub Pages keeps a global “pages” queue per repo. When a deploy for main is waiting/running, GitHub will cancel other runs that it thinks conflict with that queue.

Your workflow-level concurrency key is group: pages-${{ github.ref }}. Because it starts with pages-, it can collide (semantically) with the Pages queue and you get messages like:

“Canceling since a higher priority waiting request for pages-refs/heads/main exists”