### PR TITLE
ci: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,8 @@
     "config:recommended",
     ":semanticCommits",
     ":dependencyDashboard",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    "helpers:pinGitHubActionDigests"
   ],
   "mise": {"enabled": true},
   "timezone": "America/New_York",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         # using Hugo Modules, not submodules
         with:
           submodules: false
@@ -40,7 +40,7 @@ jobs:
 
       # Replace your Setup Go + Setup Hugo steps with this block
       - name: Setup Mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           install: true # runs `mise install` (reads mise.toml)
           cache: true
@@ -88,7 +88,7 @@ jobs:
           echo "gobuildcache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Go
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ${{ steps.gopaths.outputs.gomodcache }}
@@ -98,7 +98,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Cache Hugo
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cache/hugo
@@ -113,7 +113,7 @@ jobs:
 
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Build /public
         run: |
@@ -125,7 +125,7 @@ jobs:
 
       # Always upload a normal artifact for downstream jobs
       - name: Upload Site Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: site
           path: ./public
@@ -136,7 +136,7 @@ jobs:
       # Only upload the special Pages artifact when deploying from main
       - name: Upload Pages Artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./public
 
@@ -151,7 +151,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           fail: false
           args: >-
@@ -218,7 +218,7 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
   purge-cloudflare:
     name: Purge Cloudflare Cache
@@ -230,7 +230,7 @@ jobs:
       contents: none
     steps:
       - name: Purge Cache
-        uses: jakejarvis/cloudflare-purge-action@v0.3.0
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # v0.3.0
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
## Summary

- pin every active GitHub Action reference to the full commit SHA currently behind its selected release tag
- retain version comments such as `# v7` for readability
- enable Renovate's `helpers:pinGitHubActionDigests` preset so pinned action digests remain maintainable

This includes the Cloudflare purge action, which receives the Cloudflare token during deployment.

## Validation

- resolved each SHA directly from the action repository's selected tag
- verified there are no active `uses:` entries remaining on movable version tags
- parsed the updated workflow as valid YAML
- ran `git diff --check`