### PR TITLE
ci: harden Hugo validation and deployment gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,8 @@ jobs:
   linkcheck:
     name: Link Check
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies'))
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -223,7 +222,7 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build, linkcheck]
+    needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,21 +120,7 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Build /public
-        run: |
-          build_log="$(mktemp)"
-          hugo --minify --gc --enableGitInfo 2>&1 | tee "$build_log"
-
-          # PaperMod still calls two Hugo language methods deprecated in v0.158.0.
-          # Fail on every other warning without vendoring or forking the theme.
-          unexpected_warnings="$({
-            grep '^WARN' "$build_log" || true
-          } | grep -Ev 'deprecated: \.Language\.(LanguageDirection|LanguageCode)' || true)"
-
-          if [ -n "$unexpected_warnings" ]; then
-            echo "Unexpected Hugo warnings detected:"
-            echo "$unexpected_warnings"
-            exit 1
-          fi
+        run: hugo --minify --gc --enableGitInfo
 
       # Fail if build produced no index
       - name: Verify Build Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ env:
   CI: true
   HUGO_ENVIRONMENT: production
   HUGO_ENV: production
-  HUGO_PANIC_ON_WARNING: "false" # "true" if you want stricter builds
   GOTOOLCHAIN: local # enforce using the installed Go for all steps
 
 jobs:
@@ -109,7 +108,12 @@ jobs:
 
       # Surface module issues early (uses the Go toolchain above)
       - name: Hugo Modules Tidy
-        run: hugo mod tidy
+        run: |
+          hugo mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Hugo Modules Verify
+        run: hugo mod verify
 
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -117,7 +121,20 @@ jobs:
 
       - name: Build /public
         run: |
-          hugo --minify --gc --enableGitInfo $([ "${HUGO_PANIC_ON_WARNING}" = "true" ] && echo "--panicOnWarning")
+          build_log="$(mktemp)"
+          hugo --minify --gc --enableGitInfo 2>&1 | tee "$build_log"
+
+          # PaperMod still calls two Hugo language methods deprecated in v0.158.0.
+          # Fail on every other warning without vendoring or forking the theme.
+          unexpected_warnings="$({
+            grep '^WARN' "$build_log" || true
+          } | grep -Ev 'deprecated: \.Language\.(LanguageDirection|LanguageCode)' || true)"
+
+          if [ -n "$unexpected_warnings" ]; then
+            echo "Unexpected Hugo warnings detected:"
+            echo "$unexpected_warnings"
+            exit 1
+          fi
 
       # Fail if build produced no index
       - name: Verify Build Output
@@ -143,8 +160,9 @@ jobs:
   linkcheck:
     name: Link Check
     if: >
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -205,7 +223,7 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: build
+    needs: [build, linkcheck]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 baseURL: https://alexdiliberto.com
 title: Alex DiLiberto
-languageCode: en-us
+locale: en-US
 enableRobotsTXT: true
 enableEmoji: true
 

--- a/layouts/shortcodes/ember_addons.html
+++ b/layouts/shortcodes/ember_addons.html
@@ -1,6 +1,6 @@
 {{- $class := .Get "class" | default "ember-addons-ul" -}}
 {{- $title := .Get "title" -}}
-{{- $items := site.Data.ember_addons | default (slice) -}}
+{{- $items := hugo.Data.ember_addons | default (slice) -}}
 
 <section class="ember-addons-section">
   {{ with $title }}<h2>{{ . }}</h2>{{ end }}

--- a/layouts/shortcodes/talks.html
+++ b/layouts/shortcodes/talks.html
@@ -1,6 +1,6 @@
 {{- $title := .Get "title" -}}
 {{- $class := .Get "class" | default "talks-list" -}}
-{{- $items := site.Data.talks | default (slice) -}}
+{{- $items := hugo.Data.talks | default (slice) -}}
 
 <section class="talks-section">
   {{ with $title }}<h2>{{ . }}</h2>{{ end }}


### PR DESCRIPTION
## Summary

- replace Hugo's deprecated top-level `languageCode` setting with `locale`
- migrate the custom data shortcodes from `site.Data` to `hugo.Data`
- verify Hugo modules and fail when `hugo mod tidy` changes tracked module files

Hugo warnings remain visible in the build log but do not fail the build. Strict `--panicOnWarning` behavior is intentionally deferred until PaperMod resolves [its deprecated language-method calls](https://github.com/adityatelange/hugo-PaperMod/issues/1856), avoiding custom log parsing or local theme overrides.

Link checking remains limited to non-dependency pull requests and does not run on or gate deployments from `main`.

## Validation

- `hugo mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `hugo mod verify`
- production Hugo build using Hugo 0.165.0 and Go 1.26.6
- verified 43 pages and a nonempty `public/index.html`
- parsed the updated workflow as valid YAML

Closes #151