### PR TITLE
build: exclude legacy presentation tooling from the published site

### DIFF
--- a/docs/legacy-presentations.md
+++ b/docs/legacy-presentations.md
@@ -1,0 +1,22 @@
+# Legacy presentation publishing
+
+The presentations under `static/talks/` are frozen Reveal.js 3.6 artifacts.
+They are retained so their existing URLs continue to work, but they are not part
+of the Hugo site's active JavaScript toolchain.
+
+Hugo's static mount excludes development-only files from the generated site:
+
+- Node and Bower package manifests
+- Yarn lockfiles
+- Grunt build configuration
+- Reveal.js repository documentation
+- Test suites and fixtures
+
+The runtime HTML, JavaScript, CSS, fonts, images, and presentation content remain
+published. Renovate intentionally ignores npm dependencies in `static/talks/**`
+because upgrading the archived source in place could break the presentations.
+
+When editing this policy, verify both presentations after a production build:
+
+- `/talks/all-things-git/`
+- `/talks/extending-ember-with-analytics/`

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,5 +120,15 @@ menu:
       weight: 50
 
 module:
+  mounts:
+    - source: static
+      target: static
+      files:
+        - "! talks/**/package.json"
+        - "! talks/**/bower.json"
+        - "! talks/**/Gruntfile.js"
+        - "! talks/**/yarn.lock"
+        - "! talks/**/README.md"
+        - "! talks/**/test/**"
   imports:
     - path: github.com/adityatelange/hugo-PaperMod


### PR DESCRIPTION
## Summary

- add a Hugo static mount that excludes development-only files from the two frozen Reveal.js 3.6 presentation bundles
- stop publishing package manifests, lockfiles, Grunt configuration, repository READMEs, and test suites
- document the presentations' frozen-artifact maintenance policy
- retain the runtime HTML, JavaScript, CSS, fonts, images, and presentation content

This intentionally avoids upgrading Reveal.js in place, which could break the historical decks.

## Validation

- `hugo mod verify`
- production Hugo build using Hugo 0.165.0 and Go 1.26.6
- both presentation entry pages remain present
- excluded development files are absent from `public/`
- Hugo static-file output decreases from 267 files to 205