### PR TITLE
chore: remove stale PaperMod submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/PaperMod"]
-	path = themes/PaperMod
-	url = https://github.com/adityatelange/hugo-PaperMod.git


### PR DESCRIPTION
## Summary

Remove the obsolete `.gitmodules` declaration for `themes/PaperMod`.

The site currently loads PaperMod through Hugo Modules in `go.mod`, and CI explicitly checks out with `submodules: false`. The declared submodule path is not present in the repository.

## Validation

- confirmed PaperMod remains declared as a Hugo Module
- confirmed the production workflow does not initialize submodules