### PR TITLE
docs: correct Hugo badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Alex's Personal Website &amp; Blog</h1>
 
 <p align="center">
-  <a href="https://gohugo.io/"><img src="https://img.shields.io/badge/Built%20with-Hugo-blue.svg" alt="Built with Jekyll"></a>
+  <a href="https://gohugo.io/"><img src="https://img.shields.io/badge/Built%20with-Hugo-blue.svg" alt="Built with Hugo"></a>
   <a href="https://en.wikipedia.org/wiki/MIT_License"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT"></a>
   <a href="https://github.com/alexdiliberto/alexdiliberto.github.io/actions/workflows/ci.yml"><img src="https://github.com/alexdiliberto/alexdiliberto.github.io/actions/workflows/ci.yml/badge.svg?branch=main" alt="Deploy Hugo to GitHub Pages"></a>
 </p>


### PR DESCRIPTION
## Summary

Correct the Hugo badge's alternative text from `Built with Jekyll` to `Built with Hugo`.

This changes documentation only.

## Validation

- confirmed the visible badge and its destination already reference Hugo
- ran `git diff --check`