### PR TITLE
chore(deps): update PaperMod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/alexdiliberto/alexdiliberto.github.io
 
 go 1.26.6
 
-require github.com/adityatelange/hugo-PaperMod v0.0.0-20260308172054-10d3dcc0e05c // indirect
+require github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/adityatelange/hugo-PaperMod v0.0.0-20260308172054-10d3dcc0e05c h1:UYJTl/vtAFc1fMjhLNzhr9niW8TexCTkh0eAlAJdSRg=
-github.com/adityatelange/hugo-PaperMod v0.0.0-20260308172054-10d3dcc0e05c/go.mod h1:HCHxNMKYdGafUYjVV3ICiAqznZK2yH0iI53jqcDFDdQ=
+github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a h1:Bkfmfl/zjay3M8OOMx7tALMHDYc9jRwj5rUKN4OzOPc=
+github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a/go.mod h1:sp5WH671pzcVNpWKveBQKlBfu6T9uvcBI/4B3BSojKw=


### PR DESCRIPTION
## Summary

Update the PaperMod Hugo Module from:

- `v0.0.0-20260308172054-10d3dcc0e05c`

to:

- `v0.0.0-20260802175912-d3768854d00a`

The target is the current upstream `master` commit inspected on August 24, 2026.

## Validation

- `hugo mod tidy`
- `hugo mod verify`
- production Hugo build using Hugo 0.165.0 and Go 1.26.6
- verified 43 generated pages and a nonempty site output

The upstream theme still emits two Hugo language-method deprecation warnings. Those are handled explicitly by the separate CI-hardening PR rather than hidden here.

Closes #152